### PR TITLE
Fix: double-step to use gh secret

### DIFF
--- a/.github/workflows/execute-python-tests.yml
+++ b/.github/workflows/execute-python-tests.yml
@@ -27,7 +27,10 @@ jobs:
     - name: Create staging.env file
       run: |
         touch .staging.env
-        echo DATABASE_CONNECTION_STRING=${{ secrets.DB_CONNECTION_STRING }} >> .staging.env
+        echo DATABASE_CONNECTION_STRING=${DBCS} >> .staging.env
+      env:
+        DBCS: ${{ secrets.DB_CONNECTION_STRING }}
+        
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
As failed result of PR #8 tests presents, the single step of using GitHub secrets did not work. 

A tip found [here](https://stackoverflow.com/a/71166556) pointed out that doing a double step should resolve.